### PR TITLE
Add id to serializer to pass merchant records in spec harness

### DIFF
--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,4 +1,4 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :name
+  attributes :id, :name
 end


### PR DESCRIPTION
Running just the test/records/merchants_test.rb within the spec harness now passes with the :id added to the merchant serializer.